### PR TITLE
优化InsertBatch，不再需要make([]interface{})和for来转换类型

### DIFF
--- a/orm/inner.go
+++ b/orm/inner.go
@@ -789,9 +789,11 @@ func columnsByStruct(s interface{}) (string, string, []interface{}, reflect.Valu
 	return cols, vals, ret, pk, isAi
 }
 
-func columnsBySlice(s []interface{}) (string, string, []interface{}, []reflect.Value, []bool) {
-	t := reflect.TypeOf(s[0]).Elem()
-	ret := make([]interface{}, 0, t.NumField()*len(s))
+func columnsBySlice(s interface{}) (string, string, []interface{}, []reflect.Value, []bool) {
+	rt := reflect.TypeOf(s)
+	rv := reflect.ValueOf(s)
+	t := rt.Elem().Elem()
+	ret := make([]interface{}, 0, t.NumField()*rv.Len())
 	cols := "("
 	isFirst := true
 	for k := 0; k < t.NumField(); k++ {
@@ -816,14 +818,14 @@ func columnsBySlice(s []interface{}) (string, string, []interface{}, []reflect.V
 	cols += ")"
 
 	vals := bytes.Buffer{}
-	pks := make([]reflect.Value, len(s))
-	ais := make([]bool, len(s))
-	for n, record := range s {
-		ct := reflect.TypeOf(record).Elem()
+	pks := make([]reflect.Value, rv.Len())
+	ais := make([]bool, rv.Len())
+	for n := 0; n < rv.Len(); n++ {
+		ct := rv.Index(n).Type().Elem()
 		if ct.Name() != t.Name() {
 			continue
 		}
-		v := reflect.ValueOf(record).Elem()
+		v := rv.Index(n).Elem()
 		if n > 0 {
 			vals.WriteString(",")
 		}
@@ -880,13 +882,15 @@ func insert(tdx Tdx, s interface{}) error {
 	return nil
 }
 
-func insertBatch(tdx Tdx, s []interface{}) error {
-	if s == nil || len(s) == 0 {
+func insertBatch(tdx Tdx, s interface{}) error {
+	rv := reflect.ValueOf(s)
+
+	if s == nil || rv.Len() == 0 {
 		return nil
 	}
 	//TODO: check all elements in s are in same type
 	cols, vals, ifs, pks, ais := columnsBySlice(s)
-	t := reflect.TypeOf(s[0]).Elem()
+	t := reflect.TypeOf(s).Elem().Elem()
 
 	q := fmt.Sprintf("insert into `%s` %s values %s", fieldName2ColName(t.Name()), cols, vals)
 	ret, err := tdx.Exec(q, ifs...)
@@ -898,7 +902,7 @@ func insertBatch(tdx Tdx, s []interface{}) error {
 	if err != nil {
 		return err
 	}
-	for i, _ := range s {
+	for i := 0; i < rv.Len(); i++ {
 		if ais[i] {
 			pks[i].SetInt(lastInsertId + int64(i))
 		}

--- a/orm/orm.go
+++ b/orm/orm.go
@@ -35,7 +35,7 @@ type ORMer interface {
 	SelectInt(string, ...interface{}) (int64, error)
 	SelectFloat64(string, ...interface{}) (float64, error)
 	Insert(interface{}) error
-	InsertBatch([]interface{}) error
+	InsertBatch(interface{}) error
 	Exec(string, ...interface{}) (sql.Result, error)
 	ExecWithParam(string, interface{}) (sql.Result, error)
 	ExecWithRowAffectCheck(int64, string, ...interface{}) error
@@ -163,7 +163,7 @@ func (o *ORM) Insert(s interface{}) error {
 	return insert(o.db, s)
 }
 
-func (o *ORM) InsertBatch(s []interface{}) error {
+func (o *ORM) InsertBatch(s interface{}) error {
 	return insertBatch(o.db, s)
 }
 
@@ -230,7 +230,7 @@ func (o *ORMTran) Insert(s interface{}) error {
 	return insert(o.tx, s)
 }
 
-func (o *ORMTran) InsertBatch(s []interface{}) error {
+func (o *ORMTran) InsertBatch(s interface{}) error {
 	return insertBatch(o.tx, s)
 }
 
@@ -342,7 +342,7 @@ func Insert(s interface{}) error {
 	return Default.Insert(s)
 }
 
-func InsertBatch(s []interface{}) error {
+func InsertBatch(s interface{}) error {
 	return Default.InsertBatch(s)
 }
 

--- a/orm/orm_test.go
+++ b/orm/orm_test.go
@@ -691,3 +691,52 @@ func TestSelectFloat64(t *testing.T) {
 		}
 	})
 }
+
+func TestSelectFloat64Interface(t *testing.T) {
+	oneTestScope(func(orm *ORM) {
+		list := make([]interface{}, 0, 2)
+		for i := 0; i < 2; i++ {
+			list = append(list, &TestOrmA123{
+				OtherId:     1,
+				Description: "test orm 1测试",
+				StartDate:   time.Now(),
+				EndDate:     time.Now(),
+			})
+		}
+		orm.InsertBatch(list)
+		//fmt.Println("insert 2 records cost time ", time.Now().Sub(start))
+		ret, _ := orm.SelectFloat64("select avg(test_id) from test_orm_a123")
+		fmt.Println(ret)
+		if ret != 1.5 {
+			t.Fatal("error!")
+		}
+	})
+}
+
+func TestSelectFloat64IllegalInput(t *testing.T) {
+	oneTestScope(func(orm *ORM) {
+		err := orm.InsertBatch(nil)
+		t.Log(err)
+		objs := make([]*TestOrmA123, 0)
+		err = orm.InsertBatch(objs)
+		t.Log(err)
+		err = orm.InsertBatch(&TestOrmA123{
+			OtherId:     1,
+			Description: "test orm 1测试",
+			StartDate:   time.Now(),
+			EndDate:     time.Now(),
+		})
+		t.Log(err)
+		err = orm.InsertBatch(map[string]string{
+			"other_id":"1",
+			"description":"test orm ceshi",
+		})
+		t.Log(err)
+		//fmt.Println("insert 2 records cost time ", time.Now().Sub(start))
+		ret, _ := orm.SelectFloat64("select avg(test_id) from test_orm_a123")
+		fmt.Println(ret)
+		if ret != 1.5 {
+			t.Fatal("error!")
+		}
+	})
+}

--- a/orm/orm_test.go
+++ b/orm/orm_test.go
@@ -135,8 +135,7 @@ func TestQueryRawSetAndQueryRaw(t *testing.T) {
 			EndDate:     time.Now(),
 		}
 
-		ps := make([]interface{}, 0)
-		ps = append(ps, p1, p2)
+		ps := []*TestOrmA123{p1, p2}
 
 		err := InsertBatch(ps)
 		fmt.Println(err)
@@ -674,7 +673,7 @@ func TestPanicHandlingInTransaction(t *testing.T) {
 
 func TestSelectFloat64(t *testing.T) {
 	oneTestScope(func(orm *ORM) {
-		list := make([]interface{}, 0, 2)
+		list := make([]*TestOrmA123, 0, 2)
 		for i := 0; i < 2; i++ {
 			list = append(list, &TestOrmA123{
 				OtherId:     1,


### PR DESCRIPTION
原来的代码是这样的
func (s *Model) InsertActivity(activityTaskGathers []*ActivityTaskGather) error {
	list := make([]interface{}, 0)
	for _, a := range activityTaskGathers {
		list = append(list, a)
	}
	return s.m.InsertBatch(list)
}
修改之后不再需要
list := make([]interface{}, 0)
	for _, a := range activityTaskGathers {
		list = append(list, a)
	}
这样来转换了